### PR TITLE
fix: fix 404 error when reloading UI

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+:80
+
+root * /var/www/html
+
+try_files {path} index.html
+
+file_server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM caddy:2.1.1
 
+COPY Caddyfile /etc/caddy/
 COPY ./dist/* /var/www/html/


### PR DESCRIPTION
When using Caddy to host a single-page application (SPA), a special configuration must be set in order to route pages to `/index.html`.

Closes #8