### PR TITLE
fix: sort the date of the series chronologically

### DIFF
--- a/src/scheduler/resources.ts
+++ b/src/scheduler/resources.ts
@@ -27,7 +27,7 @@ autorun(
                             item[measurement.name] = measurement.usage
                         })
                         runInAction(() => {
-                            series.data = Object.keys(values).map(it => values[it]) // TODO: is there a better idiomatic way of retrieving values
+                            series.data = Object.keys(values).sort().map(it => values[it]) // TODO: is there a better idiomatic way of retrieving values
                             series.state.updatedAt = new Date()
                             koaStore.clearError(series.state)
                         })


### PR DESCRIPTION
Addresses #11.

Some resources may have partial data, for instance the resource `redis`:

```json
[
    {
        "name": "redis",
        "dateUTC": "2020-07-31T05:00:00Z",
        "usage": 0
    },
    {
        "name": "redis",
        "dateUTC": "2020-07-31T06:00:00Z",
        "usage": 3.265199
    },
    {
        "name": "kube-system",
        "dateUTC": "2020-07-30T15:00:00Z",
        "usage": 1.207825
    },
    {
        "name": "kube-system",
        "dateUTC": "2020-07-30T16:00:00Z",
        "usage": 1.810912
    },
    {
        "name": "kube-system",
        "dateUTC": "2020-07-30T17:00:00Z",
        "usage": 1.171079
    },
 ...
]
```

The fix is straightforward and consists of sorting the data.

