### PR TITLE
fix: fix usage history request parameters

### DIFF
--- a/src/client/usagehistory.ts
+++ b/src/client/usagehistory.ts
@@ -27,7 +27,7 @@ export const getUsageHistory = async (endpoint: string, startDateUTC?: Date, end
     const resource = '/usagehistory'
 
     return axios
-        .get(endpoint + '/api/usagehistory', { params: { startDate: startDateUTC?.toISOString(), endDate: endDateUTC?.toISOString() } })
+        .get(getUsageHistoryDownloadLink(endpoint, startDateUTC, endDateUTC))
         .then(res => res.data)
         .then(data => {
             if (data.status !== 'ok') {
@@ -41,17 +41,27 @@ export const getUsageHistory = async (endpoint: string, startDateUTC?: Date, end
 }
 
 export const getUsageHistoryDownloadLink = (endpoint: string, startDateUTC?: Date, endDateUTC?: Date, formatType?: FormatType) => {
-    let url = endpoint + '/api/usagehistory'
+    let url = endpoint + '/api/usagehistory?'
 
-    url = url + `?format=${formatType ? formatType : FormatType.JSON}`
+    let prepend = ''
 
     if (startDateUTC) {
-        url = url + `&startDate=${startDateUTC?.toISOString()}`
+        url = url + `${prepend}startDateUTC=${toUTC(startDateUTC)}`
+        prepend = '&'
     }
 
     if (endDateUTC) {
-        url = url + `&endDate=${endDateUTC?.toISOString()}`
+        url = url + `${prepend}endDateUTC=${toUTC(endDateUTC)}`
+        prepend = '&'
+    }
+
+    if (formatType) {
+        url = url + `${prepend}format=${formatType}`
+        prepend = '&'
     }
 
     return url
 }
+
+const toUTC = (date?: Date) =>
+    date?.toISOString().replace(/(\.\d*)?Z/, "")


### PR DESCRIPTION
Fixes #13.

The request sent for usage history now looks like:

```
/api/usagehistory?startDateUTC=2020-08-01T10:35:39&endDateUTC=2020-08-02T10:36:12
```

- provide `startDateUTC` and `endDateUTC` as query parameters for date range
- provide dates as UTC strings without millis nor timezone.