### PR TITLE
chore: align header cosmetic with app website

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,6 +52,12 @@ const useStyles = makeStyles(theme => ({
             display: 'none'
         }
     },
+    brandIcon: {
+        maxHeight: '30px',
+        maxWidth: '100%',
+        marginTop: '9px',
+        marginLeft: '23px'
+    },
     drawer: {},
     drawerPaper: {
         width: drawerWidth,
@@ -65,6 +71,7 @@ const useStyles = makeStyles(theme => ({
         flexGrow: 1
     },
     link: {
+        color: 'rgba(255,255,255,0.8)',
         textTransform: 'uppercase',
         paddingBottom: '3px',
         margin: theme.spacing(1, 1.5),
@@ -161,7 +168,7 @@ const Header = () => {
                     <MenuIcon />
                 </IconButton>
                 <Typography variant="h6" noWrap className={classes.toolbarTitle}>
-                    <img src={Logo} alt="Krossboard logo" />
+                    <img className={classes.brandIcon} src={Logo} alt="Krossboard logo" />
                 </Typography>
                 <nav>
                     <Drawer
@@ -183,6 +190,7 @@ const Header = () => {
                                     component={NavLink}
                                     to={it.to}
                                     color="textSecondary"
+                                    className={classes.link}
                                     activeClassName={classes.itemSelected}
                                     exact={it.exact}
                                     onClick={() => setDrawerOpened(false)}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,12 @@
 import { createMuiTheme } from '@material-ui/core'
 
 const palette = {
-    primary: { main: '#E3F2FD' },
-    secondary: { main: '#4DB6AC' }
+    primary: {
+        main: '#434B64',
+    },
+    secondary: {
+        main: '#4DB6AC'
+    }
 }
 
 export const theme = createMuiTheme({


### PR DESCRIPTION
Following #22 discussion, here's the PR which aligs the header cosmetic with the one in the app website.

Not perfect, but I hope it's give a better consistency.