### PR TITLE
🚨 Fix broken build due to insecure commands

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.1.0
 
-    - uses: actions/setup-node@v1.4.1
+    - uses: actions/setup-node@v2
       with:
         node-version: '12.16.2'
     - id: yarn-cache-dir-path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.1.0
-    - uses: actions/setup-node@v1.4.1
+    - uses: actions/setup-node@v2
       with:
         node-version: '12.16.2'
     - id: yarn-cache-dir-path


### PR DESCRIPTION
Fix broken build:
```
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.
```

see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Hence, we updated the version of the plugin `action/setup-node` to the latest available one.