### PR TITLE
ci(workflow): declare commitlint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
+  check-commits:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - if: "(github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')"
+        name: Check commits
+        uses: wagoid/commitlint-github-action@v2
+
   build:
     runs-on: ubuntu-18.04
 


### PR DESCRIPTION
Additional [step](https://github.com/wagoid/commitlint-github-action) to the CI workflow that checks that commit follow conventional commit conventions.