### PR TITLE
feat(ui): make selected menu item darker

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -150,7 +150,13 @@ const useStyles = makeStyles(theme => ({
             paddingTop: theme.spacing(2),
             paddingBottom: '0px'
         }
-    }
+    },
+    listItemRoot: {
+        '&$selected': {
+          backgroundColor: theme.palette.primary.dark
+        },
+    },
+    selected: {},
 }))
 
 export const App = () => {
@@ -252,6 +258,7 @@ const Header = () => {
                                         button
                                         color="textSecondary"
                                         className={classes.link}
+                                        classes={{ root: classes.listItemRoot, selected: classes.selected }}
                                         component={NavLink}
                                         to={it.to}
                                         exact={true}


### PR DESCRIPTION
Make the selected menu item darker (a bit).

Before:

<img width="985" alt="image" src="https://user-images.githubusercontent.com/9574336/121860458-26836380-ccf9-11eb-83b3-8ba82d4e3aff.png">

After:

<img width="988" alt="image" src="https://user-images.githubusercontent.com/9574336/121859967-a8bf5800-ccf8-11eb-9563-b1653552c932.png">

