### PR TITLE
fix(page)!: rename namespaces-usage by clusters-usage

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,7 +9,7 @@ on:
       - main
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2.1.0
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,4 +1,3 @@
-
 name: Build Docker image
 on:
   push:
@@ -7,6 +6,11 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -15,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.16.2'
+          node-version: "12.16.2"
       - id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-commits:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
         uses: wagoid/commitlint-github-action@v2
 
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-commits:
@@ -23,24 +27,22 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2.1.0
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '12.16.2'
-    - id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-    - uses: actions/cache@v1
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: install dependencies
-      run: yarn
-    - name: analyse code
-      run: yarn lint
-    - name: build
-      run: yarn build
-
-
+      - uses: actions/checkout@v2.1.0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.16.2"
+      - id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn
+      - name: analyse code
+        run: yarn lint
+      - name: build
+        run: yarn build

--- a/src/app/menu.ts
+++ b/src/app/menu.ts
@@ -13,9 +13,9 @@
 
 import { useEffect, useState } from 'react'
 import { matchPath, useLocation } from 'react-router'
+import { ClusterUsageView } from '../pages/ClusterUsage'
 import { ClusterUsageCurrentView } from '../pages/ClusterUsageCurrent'
 import { ClusterUsageHistoryView } from '../pages/ClusterUsageHistory'
-import { NamespaceUsageView } from '../pages/NamespaceUsage'
 import { NodeUsageHistoryView } from '../pages/NodeUsageHistory'
 import { NodeUsageRecentOccupationView } from '../pages/NodeUsageRecentOccupation'
 
@@ -52,10 +52,10 @@ export const menus: IMenu[][] = [
     ],
     [
         {
-            to: '/namespaces-usage',
-            primary: 'Namespaces usage',
-            secondary: 'Namespaces Usage',
-            view: NamespaceUsageView
+            to: '/cluster-usage',
+            primary: 'Cluster usage',
+            secondary: 'Cluster Usage',
+            view: ClusterUsageView
         }
     ],
     [

--- a/src/pages/ClusterUsage.tsx
+++ b/src/pages/ClusterUsage.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles(theme => ({
     }
 }))
 
-export const NamespaceUsageView = () => {
+export const ClusterUsageView = () => {
     const classes = useStyles()
     const store = useStore()
     const dateRange = useLocalStore(() => ({


### PR DESCRIPTION
As reported by @rchakode, change the menu label from `NAMESPACES USAGE` to `CLUSTER USAGE`, and update the page name to match. This modification leads to a breaking change due to the modification of the page's route (URL).

\+ applies the same recipe as in the PR https://github.com/2-alchemists/krossboard-docs/pull/99.

![image](https://github.com/2-alchemists/krossboard-ui/assets/9574336/6a6f8b26-9a74-4a62-9987-152aafa5dfd7)
